### PR TITLE
Add scholarship eligibility checker page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,31 @@ python3 -m http.server 8000
 ## Project structure
 
 - `index.html` — page structure and form
-- `styles.css` — responsive styling (light + dark mode)
+- `styles.css` — responsive styling (light + dark mode), shared by both pages
 - `script.js` — calculation engine and UI logic
+- `scholarship.html` — scholarship eligibility checker page
+- `scholarship.js` — eligibility rules and UI logic
+
+## Scholarship eligibility checker
+
+`scholarship.html` is a self-service eligibility checker that mirrors the calculator's
+design. An applicant answers a short set of yes/no questions and gets an at-a-glance
+verdict — *eligible* or *not yet* — with a per-requirement checklist and next steps,
+plus a live countdown to the June 19, 2026 deadline.
+
+It checks the published rules: one scholarship per year, no repeat wins of the same
+scholarship, registration before the Fall 2026 semester, enrollment in Fall 2026
+courses, submission via the official form, **no identifying information in the uploaded
+application**, and agreement to public recognition. The checker collects no personal
+information and is not an official determination.
+
+Each rule is a small entry in the `REQUIREMENTS` array in `scholarship.js`, so the
+logic is transparent and easy to tune. Two values at the top of that file are meant to
+be filled in for your deployment:
+
+- `SUBMISSION_FORM_URL` — defaults to `"#"`; set it to the real Scholarship Application
+  Submission Form URL.
+- `CONTACT_EMAIL` — the questions inbox (`Say-Scholarships@saybrook.edu`).
 
 ## How the calculation works
 

--- a/index.html
+++ b/index.html
@@ -197,6 +197,7 @@
         guidance from a qualified healthcare provider. Numbers come from population averages and well-known
         epidemiological factors; individual results vary.
       </p>
+      <p><a href="scholarship.html">Scholarship eligibility checker &rarr;</a></p>
     </div>
   </footer>
 

--- a/scholarship.html
+++ b/scholarship.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scholarship Eligibility Checker</title>
+  <meta name="description" content="A self-service checker that tells you whether you appear eligible to apply for this year's scholarships before you submit." />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="container">
+      <h1>Scholarship Eligibility Checker</h1>
+      <p class="tagline">Answer a few quick questions to see whether you appear eligible to apply &mdash; before you submit.</p>
+      <p class="disclaimer-pill" role="note">Unofficial self-check &mdash; not an eligibility determination</p>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="card keydates" aria-label="Key dates">
+      <div class="keydates-grid">
+        <div class="keydate">
+          <span class="keydate-label">Application deadline</span>
+          <strong class="keydate-value">June 19, 2026</strong>
+          <small id="countdown" class="keydate-note" aria-live="polite">&mdash;</small>
+        </div>
+        <div class="keydate">
+          <span class="keydate-label">Winners notified by</span>
+          <strong class="keydate-value">July 20, 2026</strong>
+        </div>
+        <div class="keydate">
+          <span class="keydate-label">Award applies to</span>
+          <strong class="keydate-value">Fall 2026 semester</strong>
+        </div>
+      </div>
+    </section>
+
+    <form id="eligibility-form" novalidate aria-describedby="form-intro">
+      <p id="form-intro" class="form-intro">
+        This check asks for <strong>no identifying information</strong> and stores nothing. Each answer is matched against
+        the published eligibility rules. A final determination is made by the University.
+      </p>
+
+      <fieldset class="card">
+        <legend>This year&rsquo;s application</legend>
+        <div class="grid">
+          <label class="field">
+            <span>How many of this year&rsquo;s nine scholarships are you applying to?</span>
+            <select name="count" required>
+              <option value="">Select&hellip;</option>
+              <option value="one">Just one</option>
+              <option value="multiple">More than one</option>
+            </select>
+            <small class="hint">You may apply for only one scholarship per year.</small>
+            <small class="error" data-error-for="count"></small>
+          </label>
+          <label class="field">
+            <span>Have you previously won this specific scholarship?</span>
+            <select name="wonBefore" required>
+              <option value="">Select&hellip;</option>
+              <option value="no">No</option>
+              <option value="yes">Yes</option>
+            </select>
+            <small class="hint">Each scholarship can be won only once in a lifetime.</small>
+            <small class="error" data-error-for="wonBefore"></small>
+          </label>
+        </div>
+      </fieldset>
+
+      <fieldset class="card">
+        <legend>Enrollment</legend>
+        <div class="grid">
+          <label class="field">
+            <span>Will you be registered before the start of the Fall 2026 semester?</span>
+            <select name="register" required>
+              <option value="">Select&hellip;</option>
+              <option value="yes">Yes</option>
+              <option value="no">No</option>
+            </select>
+            <small class="hint">Registration must be complete before the semester begins.</small>
+            <small class="error" data-error-for="register"></small>
+          </label>
+          <label class="field">
+            <span>Will you be enrolled in courses during the Fall 2026 semester?</span>
+            <select name="enroll" required>
+              <option value="">Select&hellip;</option>
+              <option value="yes">Yes</option>
+              <option value="no">No</option>
+            </select>
+            <small class="hint">The award is applied to your student account for that semester.</small>
+            <small class="error" data-error-for="enroll"></small>
+          </label>
+        </div>
+      </fieldset>
+
+      <fieldset class="card">
+        <legend>Submission</legend>
+        <div class="grid">
+          <label class="field">
+            <span>Will you submit through the official Scholarship Application Submission Form by the deadline?</span>
+            <select name="form" required>
+              <option value="">Select&hellip;</option>
+              <option value="yes">Yes</option>
+              <option value="no">No</option>
+            </select>
+            <small class="hint">Applications are accepted only through the official form, by June 19, 2026.</small>
+            <small class="error" data-error-for="form"></small>
+          </label>
+          <label class="field">
+            <span>Will your uploaded application be free of any identifying information?</span>
+            <select name="anonymous" required>
+              <option value="">Select&hellip;</option>
+              <option value="yes">Yes</option>
+              <option value="no">No</option>
+            </select>
+            <small class="hint">Contact details go on the form only. Identifying info in the upload means disqualification.</small>
+            <small class="error" data-error-for="anonymous"></small>
+          </label>
+        </div>
+      </fieldset>
+
+      <fieldset class="card">
+        <legend>Permission</legend>
+        <div class="grid">
+          <label class="field">
+            <span>If you win, do you agree to have your name, information, and images shared publicly?</span>
+            <select name="publicity" required>
+              <option value="">Select&hellip;</option>
+              <option value="yes">Yes</option>
+              <option value="no">No</option>
+            </select>
+            <small class="hint">Recipients agree to public recognition via the University&rsquo;s channels.</small>
+            <small class="error" data-error-for="publicity"></small>
+          </label>
+        </div>
+      </fieldset>
+
+      <div class="actions">
+        <button type="submit" class="btn btn-primary">Check eligibility</button>
+        <button type="reset" class="btn btn-ghost">Reset</button>
+      </div>
+    </form>
+
+    <section id="results" class="results card hidden" aria-live="polite" tabindex="-1">
+      <div id="verdict" class="verdict">
+        <span class="verdict-icon" id="verdict-icon" aria-hidden="true"></span>
+        <p class="verdict-title" id="verdict-title">&mdash;</p>
+        <p class="verdict-sub" id="verdict-sub">&mdash;</p>
+      </div>
+
+      <div class="breakdown">
+        <h2>Requirement check</h2>
+        <ul id="requirement-list" class="factor-list"></ul>
+      </div>
+
+      <div id="next-steps" class="next-steps"></div>
+
+      <button type="button" id="recheck" class="btn btn-ghost">Re-check</button>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <p>
+        This tool is an unofficial self-check to help you prepare your application. It does not collect your information
+        and is not an official eligibility decision. You may consult the Saybrook University Writing Center to strengthen
+        your written submission. Questions? Email
+        <a href="mailto:Say-Scholarships@saybrook.edu">Say-Scholarships@saybrook.edu</a>.
+      </p>
+      <p><a href="index.html">&larr; Longevity calculator</a></p>
+    </div>
+  </footer>
+
+  <script src="scholarship.js"></script>
+</body>
+</html>

--- a/scholarship.js
+++ b/scholarship.js
@@ -1,0 +1,330 @@
+(function () {
+  "use strict";
+
+  // --- Configuration -------------------------------------------------------
+  // Application closes at the end of the deadline day, local time.
+  const DEADLINE = new Date(2026, 5, 19, 23, 59, 59); // June 19, 2026 (month is 0-indexed)
+  const CONTACT_EMAIL = "Say-Scholarships@saybrook.edu";
+  // TODO: replace "#" with the real Scholarship Application Submission Form URL.
+  const SUBMISSION_FORM_URL = "#";
+
+  // --- Requirements --------------------------------------------------------
+  // Each requirement maps a form field (by name) to an evaluation of the
+  // chosen answer. `severity` distinguishes a hard "disqualify" (the answer
+  // makes the application invalid as submitted) from a "blocker" (a condition
+  // the applicant still needs to satisfy before they can qualify). Keeping the
+  // rules here as plain data makes the logic transparent and easy to tune.
+  const REQUIREMENTS = [
+    {
+      key: "count",
+      label: "One scholarship per year",
+      evaluate: (v) =>
+        v === "multiple"
+          ? {
+              ok: false,
+              severity: "disqualify",
+              note: "You may apply for only one scholarship per year — choose a single one of the nine.",
+            }
+          : { ok: true, note: "Applying to a single scholarship this year." },
+    },
+    {
+      key: "wonBefore",
+      label: "Not a previous winner of this scholarship",
+      evaluate: (v) =>
+        v === "yes"
+          ? {
+              ok: false,
+              severity: "disqualify",
+              note: "Each scholarship can be won only once in a lifetime. Consider applying for a different one.",
+            }
+          : { ok: true, note: "You have not previously won this scholarship." },
+    },
+    {
+      key: "register",
+      label: "Registered before Fall 2026",
+      evaluate: (v) =>
+        v === "no"
+          ? {
+              ok: false,
+              severity: "blocker",
+              note: "You must be registered before the Fall 2026 semester starts to qualify.",
+            }
+          : { ok: true, note: "You will be registered before Fall 2026." },
+    },
+    {
+      key: "enroll",
+      label: "Enrolled in Fall 2026 courses",
+      evaluate: (v) =>
+        v === "no"
+          ? {
+              ok: false,
+              severity: "blocker",
+              note: "The award is applied to your Fall 2026 student account, so you must be enrolled that semester.",
+            }
+          : { ok: true, note: "You will be enrolled in Fall 2026 courses." },
+    },
+    {
+      key: "form",
+      label: "Submitted via the official form by the deadline",
+      evaluate: (v) =>
+        v === "no"
+          ? {
+              ok: false,
+              severity: "blocker",
+              note: "Applications are accepted only through the official submission form, by June 19, 2026.",
+            }
+          : { ok: true, note: "You will submit through the official form by the deadline." },
+    },
+    {
+      key: "anonymous",
+      label: "No identifying information in the upload",
+      evaluate: (v) =>
+        v === "no"
+          ? {
+              ok: false,
+              severity: "disqualify",
+              note: "Identifying information in the uploaded application leads to disqualification. Remove all identifying details from the document — contact info goes on the form only.",
+            }
+          : { ok: true, note: "Your uploaded application will contain no identifying information." },
+    },
+    {
+      key: "publicity",
+      label: "Agree to public recognition if selected",
+      evaluate: (v) =>
+        v === "no"
+          ? {
+              ok: false,
+              severity: "blocker",
+              note: "Recipients must agree to have their name, information, and images shared publicly.",
+            }
+          : { ok: true, note: "You agree to public recognition if selected." },
+    },
+  ];
+
+  const $ = (sel, root = document) => root.querySelector(sel);
+  const $$ = (sel, root = document) => Array.from(root.querySelectorAll(sel));
+
+  const form = $("#eligibility-form");
+  const resultsEl = $("#results");
+  const verdictEl = $("#verdict");
+  const verdictIcon = $("#verdict-icon");
+  const verdictTitle = $("#verdict-title");
+  const verdictSub = $("#verdict-sub");
+  const requirementList = $("#requirement-list");
+  const nextStepsEl = $("#next-steps");
+  const recheckBtn = $("#recheck");
+  const countdownEl = $("#countdown");
+
+  // --- Deadline countdown --------------------------------------------------
+  function deadlinePassed() {
+    return Date.now() > DEADLINE.getTime();
+  }
+
+  function updateCountdown() {
+    const msLeft = DEADLINE.getTime() - Date.now();
+    if (msLeft <= 0) {
+      countdownEl.textContent = "The deadline has passed.";
+      return;
+    }
+    const days = Math.floor(msLeft / 86400000);
+    if (days >= 1) {
+      countdownEl.textContent = days + (days === 1 ? " day left" : " days left");
+    } else {
+      const hours = Math.max(1, Math.ceil(msLeft / 3600000));
+      countdownEl.textContent = hours + (hours === 1 ? " hour left" : " hours left");
+    }
+  }
+
+  // --- Form handling -------------------------------------------------------
+  function readForm() {
+    const data = new FormData(form);
+    const input = {};
+    REQUIREMENTS.forEach((r) => {
+      input[r.key] = data.get(r.key);
+    });
+    return input;
+  }
+
+  function validate(input) {
+    const errors = {};
+    REQUIREMENTS.forEach((r) => {
+      if (!input[r.key]) errors[r.key] = "Please answer this question";
+    });
+    return errors;
+  }
+
+  function showErrors(errors) {
+    $$(".error").forEach((el) => (el.textContent = ""));
+    $$("[aria-invalid]").forEach((el) => el.removeAttribute("aria-invalid"));
+    Object.entries(errors).forEach(([key, msg]) => {
+      const errEl = $(`[data-error-for="${key}"]`);
+      if (errEl) errEl.textContent = msg;
+      const field = form.elements[key];
+      if (field) field.setAttribute("aria-invalid", "true");
+    });
+  }
+
+  function evaluateAll(input) {
+    const checks = REQUIREMENTS.map((r) => {
+      const result = r.evaluate(input[r.key]);
+      return { label: r.label, ...result };
+    });
+
+    if (deadlinePassed()) {
+      checks.push({
+        label: "Application window open",
+        ok: false,
+        severity: "disqualify",
+        note: "The application deadline (June 19, 2026) has passed.",
+      });
+    } else {
+      checks.push({
+        label: "Application window open",
+        ok: true,
+        note: "The application window is open until June 19, 2026.",
+      });
+    }
+
+    const blockers = checks.filter((c) => !c.ok);
+    const hasDisqualifier = blockers.some((c) => c.severity === "disqualify");
+    const eligible = blockers.length === 0;
+
+    // Unmet requirements first so problems surface at the top.
+    checks.sort((a, b) => Number(a.ok) - Number(b.ok));
+
+    return { checks, blockers, hasDisqualifier, eligible };
+  }
+
+  // --- Rendering -----------------------------------------------------------
+  function renderVerdict(result) {
+    verdictEl.classList.remove("eligible", "ineligible");
+    if (result.eligible) {
+      verdictEl.classList.add("eligible");
+      verdictIcon.textContent = "✓";
+      verdictTitle.textContent = "You appear eligible to apply";
+      verdictSub.textContent =
+        "Based on your answers, you meet the eligibility requirements. Complete and submit your application before the deadline.";
+    } else {
+      verdictEl.classList.add("ineligible");
+      verdictIcon.textContent = "✕";
+      verdictTitle.textContent = result.hasDisqualifier
+        ? "Some answers would disqualify your application"
+        : "Not eligible yet";
+      const n = result.blockers.length;
+      verdictSub.textContent =
+        "Resolve the " + n + (n === 1 ? " item" : " items") + " marked below before you apply.";
+    }
+  }
+
+  function renderChecklist(checks) {
+    requirementList.innerHTML = "";
+    checks.forEach((c) => {
+      const li = document.createElement("li");
+      li.className = "factor " + (c.ok ? "positive" : "negative");
+
+      const main = document.createElement("div");
+      const name = document.createElement("span");
+      name.className = "factor-name";
+      name.textContent = c.label;
+      const note = document.createElement("span");
+      note.className = "factor-note";
+      note.textContent = c.note || "";
+      main.append(name, note);
+
+      const badge = document.createElement("span");
+      badge.className = "factor-delta";
+      badge.textContent = c.ok ? "✓" : "✕";
+      badge.setAttribute("aria-label", c.ok ? "Met" : "Not met");
+
+      li.append(main, badge);
+      requirementList.appendChild(li);
+    });
+  }
+
+  function renderNextSteps(result) {
+    nextStepsEl.innerHTML = "";
+    const h = document.createElement("h2");
+    h.textContent = "Next steps";
+    nextStepsEl.appendChild(h);
+
+    const list = document.createElement("ul");
+    list.className = "steps";
+    const steps = [];
+
+    if (result.eligible) {
+      steps.push("Prepare your application document with <strong>no identifying information</strong> in it.");
+      steps.push("Enter your contact details on the submission form (not in the uploaded document).");
+      steps.push("Submit through the official form before <strong>June 19, 2026</strong>.");
+      steps.push("Optional: ask the Saybrook University Writing Center to review your written submission.");
+    } else {
+      result.blockers.forEach((b) => steps.push(b.note));
+      steps.push("Re-check once you have addressed the items above.");
+    }
+
+    steps.forEach((text) => {
+      const li = document.createElement("li");
+      li.innerHTML = text;
+      list.appendChild(li);
+    });
+    nextStepsEl.appendChild(list);
+
+    const cta = document.createElement("div");
+    cta.className = "actions";
+
+    const apply = document.createElement("a");
+    apply.className = "btn btn-primary";
+    apply.href = SUBMISSION_FORM_URL;
+    apply.textContent = "Open the submission form";
+    if (SUBMISSION_FORM_URL === "#") {
+      apply.setAttribute("aria-disabled", "true");
+      apply.title = "Submission form link not configured yet";
+    } else {
+      apply.target = "_blank";
+      apply.rel = "noopener";
+    }
+
+    const email = document.createElement("a");
+    email.className = "btn btn-ghost";
+    email.href = "mailto:" + CONTACT_EMAIL;
+    email.textContent = "Email a question";
+
+    cta.append(apply, email);
+    nextStepsEl.appendChild(cta);
+  }
+
+  function renderResults(result) {
+    renderVerdict(result);
+    renderChecklist(result.checks);
+    renderNextSteps(result);
+    resultsEl.classList.remove("hidden");
+    resultsEl.scrollIntoView({ behavior: "smooth", block: "start" });
+    resultsEl.focus({ preventScroll: true });
+  }
+
+  form.addEventListener("submit", (e) => {
+    e.preventDefault();
+    const input = readForm();
+    const errors = validate(input);
+    showErrors(errors);
+    if (Object.keys(errors).length > 0) {
+      const firstKey = Object.keys(errors)[0];
+      const el = form.elements[firstKey];
+      if (el && typeof el.focus === "function") el.focus();
+      return;
+    }
+    renderResults(evaluateAll(input));
+  });
+
+  form.addEventListener("reset", () => {
+    showErrors({});
+    resultsEl.classList.add("hidden");
+  });
+
+  recheckBtn.addEventListener("click", () => {
+    form.scrollIntoView({ behavior: "smooth", block: "start" });
+    const firstField = form.querySelector("select");
+    if (firstField) firstField.focus();
+  });
+
+  updateCountdown();
+})();

--- a/styles.css
+++ b/styles.css
@@ -419,3 +419,119 @@ legend {
     width: 100%;
   }
 }
+
+/* ── Scholarship eligibility checker ───────────────────────────────── */
+
+a.btn {
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+a.btn[aria-disabled="true"] {
+  opacity: 0.55;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.keydates {
+  margin-bottom: var(--space-5);
+}
+
+.keydates-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: var(--space-4);
+}
+
+.keydate {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.keydate-label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+}
+
+.keydate-value {
+  font-size: 1.1rem;
+}
+
+.keydate-note {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.verdict {
+  text-align: center;
+  padding: var(--space-5);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  margin-bottom: var(--space-6);
+}
+
+.verdict.eligible {
+  background: var(--positive-soft);
+  border-color: var(--positive);
+}
+
+.verdict.ineligible {
+  background: var(--negative-soft);
+  border-color: var(--negative);
+}
+
+.verdict-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 999px;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: white;
+  margin-bottom: var(--space-2);
+}
+
+.verdict.eligible .verdict-icon {
+  background: var(--positive);
+}
+
+.verdict.ineligible .verdict-icon {
+  background: var(--negative);
+}
+
+.verdict-title {
+  margin: 0 0 var(--space-1);
+  font-size: 1.3rem;
+  font-weight: 700;
+}
+
+.verdict-sub {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.next-steps {
+  margin-top: var(--space-5);
+}
+
+.next-steps h2 {
+  font-size: 1.05rem;
+  margin: 0 0 var(--space-3);
+}
+
+.steps {
+  margin: 0 0 var(--space-5);
+  padding-left: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  color: var(--text);
+}


### PR DESCRIPTION
## What

Adds an interactive, self-service **scholarship eligibility checker** (`scholarship.html` + `scholarship.js`), styled to match the existing longevity calculator. Applicants answer a short set of questions and get an at-a-glance verdict, a per-requirement checklist, and next steps — plus a live countdown to the **June 19, 2026** deadline.

## Why

Built per request to turn the published scholarship rules into an interactive tool in this repo. The checker helps applicants self-screen before they submit, and prominently reminds them of the rule that most commonly disqualifies people: **no identifying information in the uploaded application**.

## How it works

The rules are encoded as a transparent, tunable `REQUIREMENTS` data array (mirroring the calculator's `FACTOR_DEFS` pattern). Each answer evaluates to *met*, a **blocker** (an actionable condition, e.g. "register before Fall 2026"), or a **disqualifier** (the application is invalid as submitted, e.g. identifying info in the upload, applying to more than one scholarship, or a repeat win).

Requirements checked:
- One scholarship per year
- Not a previous winner of this specific scholarship
- Registered before the Fall 2026 semester
- Enrolled in Fall 2026 courses
- Submitted via the official form by the deadline
- No identifying information in the uploaded application
- Agreement to public recognition if selected
- Application window still open (live, from the deadline date)

The page collects **no identifying information** and stores nothing; it is an unofficial self-check, not an official determination.

## Changes

- `scholarship.html` — new page (reuses `styles.css`)
- `scholarship.js` — eligibility rules + UI logic (IIFE, same conventions as `script.js`)
- `styles.css` — small scoped block (verdict banner, key-dates, link-buttons) using existing design tokens
- `index.html` — footer link to the checker for discoverability
- `README.md` — documents the page and deployment config

## Configure before deploying

- `SUBMISSION_FORM_URL` in `scholarship.js` — currently a placeholder (`"#"`); set it to the real Scholarship Application Submission Form URL. The submit button is disabled until it's set. (The contact email `Say-Scholarships@saybrook.edu` is already wired in.)

## Testing

- `node --check` passes on `scholarship.js`.
- The real shipped logic was driven through a DOM-stub harness across a 9-case truth table (all-eligible, each disqualifier, blockers, multi-blocker counts) — all passed, and the countdown correctly rendered "10 days left" for the current date. No automated test framework exists in the repo, so this was run ad hoc and not committed.

> [!NOTE]
> The names of the nine specific scholarships weren't part of the source rules, so the checker is scholarship-agnostic. If you'd like a scholarship picker or per-scholarship copy, that's an easy follow-up.

https://claude.ai/code/session_019dvj2vqogwRi3Qy1ykU16Z

---
_Generated by [Claude Code](https://claude.ai/code/session_019dvj2vqogwRi3Qy1ykU16Z)_