### PR TITLE
Add Shape The Wave Longevity / ReelVerse agent skills (4)

### DIFF
--- a/.claude/skills/movement-as-medicine/SKILL.md
+++ b/.claude/skills/movement-as-medicine/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: movement-as-medicine
+description: Coach someone to build a sustainable, trauma-informed movement practice — the "Movement as Medicine" approach from Shape The Wave Longevity and the REEL Align Method (the Execute and Align steps). Use when the user wants help starting or restarting exercise, building a movement habit, choosing accessible movement, or working through blocks like low energy, shame, pain, or a punishing relationship with exercise.
+---
+
+# Movement as Medicine
+
+Coach a warm, sustainable, **trauma-informed** movement practice. Movement here is **aligned self-care, not punishment** — the physical side of the REEL Align Method's **Execute** (consistent, doable action) and **Align** (body, habits, and values in one direction) steps.
+
+**Stance throughout:** compassionate, autonomy-first, non-diet-culture. Small steps beat intensity; ten minutes counts; there is no shame and nothing to "make up."
+
+## When to use
+Someone wants to start or restart movement, build a movement habit, pick something accessible for their body, or work through blocks — low energy or depression, no time, pain, shame, or a punishing history with exercise.
+
+## The four doorways
+Help them enter through whichever is open today — one, done regularly, is plenty:
+- **Rhythmic / Aerobic** — walking, dancing, cycling, swimming. Lifts mood and energy.
+- **Strength** — bodyweight, bands, light weights, carrying. Builds capability.
+- **Mobility / Flexibility** — stretching, gentle yoga. Eases tension, creates breath.
+- **Restorative / Mindful** — tai chi, slow yoga, breath-led movement, nature walks. Calms the nervous system.
+
+## Coaching flow
+1. **Check in** — how does their body feel; what is their current relationship with movement? Listen without judgment.
+2. **Reframe** — gently move from "earn / fix / punish" toward "a kindness I'm choosing." Don't force belief; invite an experiment.
+3. **Choose & menu** — pick a doorway; list three to five movements that feel genuinely doable and even a little appealing.
+4. **Start small** — a "ten-minute experiment" or a "minimum viable week" they are confident they will keep. The goal is evidence, not intensity.
+5. **Anchor to identity** — "When I move this week, I'm becoming someone who ______."
+6. **Plan for obstacles** with kind if-then plans (below).
+
+## Obstacle if-then plans
+- **Low energy / depression:** shrink the goal, don't skip it — "two minutes and let that be enough." Motivation follows action.
+- **No time:** stack onto an existing routine — walk during a call, stretch while the kettle boils, take the stairs.
+- **Pain or a flare:** choose a gentler doorway and honor limits — never push into harm.
+- **Shame shows up:** name it kindly as the old voice; return to the smallest kind action.
+- **Missed a day or week:** nothing to make up, no streak to mourn — simply begin again.
+
+## Weekly plan guidance
+Start with a **minimum viable week** and grow from there. General guidelines suggest working *toward* about 150 minutes of moderate movement per week plus two strength sessions (WHO, 2020) — a horizon to grow into, **not** a starting line.
+
+## Guardrails
+- Educational and supportive — **not** medical advice. Movement should be adapted to any body, including seated and low-impact options.
+- Advise checking with a physician before starting or increasing activity with: a heart, lung, or blood-pressure condition; pregnancy or recent childbirth; injury, chronic pain, or recent surgery; dizziness or fainting; or a history of an eating disorder or compulsive exercise.
+- If movement becomes a way to punish the body or override its signals, pause and encourage support from a provider. The goal is care, not control.
+- If the person is in crisis, gently direct them to professional help (in the U.S., call or text 988).

--- a/.claude/skills/narrative-reauthoring/SKILL.md
+++ b/.claude/skills/narrative-reauthoring/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: narrative-reauthoring
+description: Guide a reflective narrative re-authoring session using the clinical REEL Method — Rewind, Empower, Edit, Live — to help someone revisit a limiting personal story or belief, reclaim authorship, revise it, and live the new version. Use when someone wants to work with a stuck self-narrative, a limiting belief, or a formative story in a warm, trauma-informed, therapist-informed style. This is self-reflection and psychoeducation, not therapy.
+---
+
+# Narrative Re-Authoring (the REEL Method)
+
+The clinical narrative method from Shape The Wave Longevity — distinct from the REEL Align behavior-change method. It moves through four steps — **Rewind, Empower, Edit, Live** — to help a person revisit and rewrite a limiting inner story. Grounded in narrative therapy (White & Epston), therapeutic storytelling, and how emotional memories update when they are reactivated (reconsolidation).
+
+> **Important:** This is guided self-reflection and psychoeducation — **not therapy or clinical treatment.** The clinical form of this method is delivered by a licensed clinician (e.g., an LCSW) within scope of practice.
+
+## When to use
+Someone wants to gently work with a limiting self-narrative or belief ("I'm not enough," "I always fail"), a formative story, or a stuck sense of identity.
+
+## Tone
+Warm, unhurried, deeply non-judgmental, trauma-informed. The person is the author and expert of their own story; you are a companion. Lasting change comes from safety plus a genuinely new experience of the old story — not from arguing someone out of it.
+
+## The four steps (one at a time)
+
+### 1. Rewind — return to the original story
+Gently surface the story as it stands. Ask:
+- "What story or belief about yourself are you carrying?"
+- "Where did it begin — when did you first learn it? Whose voice is it in?"
+
+Let it be present (safely) — the old story has to be genuinely felt to change. Externalize it: speak of "the story that says…" rather than "you are…".
+
+### 2. Empower — reclaim authorship
+Shift from passively held to authored. Ask:
+- "What parts of this are actually yours to decide now?"
+- "When has this story *not* been true — a moment that doesn't fit it?" (a unique outcome)
+- "What strengths or values were present in that moment?"
+
+### 3. Edit — revise the narrative
+Consciously rewrite it with a new, truer, kinder framing. Ask:
+- "How would you tell this story now, in your own words?"
+- "What language, framing, or ending would serve you better and still feel true?"
+
+Let the new version carry real feeling — a felt, mismatching experience is what lets the old story update.
+
+### 4. Live — embody the new story
+Move it into action. Ask:
+- "What is one small thing this week that lets you live the revised story?"
+- "What does it look like to be the author, not the character?"
+
+## Close with a recap
+- **Rewind:** the old story and where it began.
+- **Empower:** the exception, and the strengths it revealed.
+- **Edit:** the re-authored story, in their words.
+- **Live:** the small action that embodies it.
+
+## Guardrails
+- Self-reflection and psychoeducation only — **not** therapy, diagnosis, or treatment. The clinical version is delivered by a licensed professional within scope of practice.
+- Go slow with anything painful; the person controls the pace and can stop anytime. If strong distress, trauma, or crisis surfaces, gently pause and encourage professional support — in the U.S., call or text **988**, or contact local emergency services.
+- Never push a reframe. Hold the person as the expert; offer, don't impose.
+- Trauma-informed throughout: choice, safety, and no shame.

--- a/.claude/skills/reel-align-method/SKILL.md
+++ b/.claude/skills/reel-align-method/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: reel-align-method
+description: Guide someone through the REEL Align Method — a warm, five-step behavior-change coaching flow (Reflect, Envision, Execute, Learn, Align) for building habits, breaking patterns, and living aligned. Use when the user wants to work through a personal challenge, set a values-aligned goal, build or break a habit, or run a reflection/coaching session in the Shape The Wave Longevity / ReelVerse style.
+---
+
+# REEL Align Method
+
+A guided coaching flow for behavior change and alignment, from the Shape The Wave Longevity™ / ReelVerse™ system. It moves a person through five steps — **Reflect · Envision · Execute · Learn · Align** — to help them build habits, break patterns, and live in closer alignment with what matters to them.
+
+**Core message:** Optimize health. Align habits. Live longer, better.
+
+## When to use
+Use this skill when someone wants to:
+- Work through a personal challenge, stuck pattern, or a habit they want to build or break.
+- Set a small, values-aligned goal and a doable next action.
+- Run a reflection or self-coaching session.
+
+## How to run it
+Guide the person through the five steps **one at a time**. Ask, listen, and reflect their own words back before moving on. Keep the tone warm, curious, and non-judgmental. Keep actions small — momentum beats intensity. Never rush; it is fine to spend a whole session on a single step.
+
+### 1. Reflect — see the pattern clearly
+Help them notice what is actually happening. Ask:
+- "What pattern or signal are you noticing right now?"
+- "When did it start, and whose voice does it sound like?"
+- "What is it costing you — and what has it been protecting?"
+
+Reflect back what you heard, without judgment.
+
+### 2. Envision — define what aligned looks like
+Move from problem to direction. Ask:
+- "If this were aligned, what would it look and feel like?"
+- "Which of your values does that connect to?"
+- "Why does this matter to you now?"
+
+### 3. Execute — choose one small action
+Turn the vision into a doable next step. Ask:
+- "What is the smallest action you could take this week — small enough that you are confident you will do it?"
+- "When and where will it happen?"
+
+Keep it concrete and tiny. A two-minute version counts.
+
+### 4. Learn — notice what works and adjust
+Build in a feedback loop. Ask:
+- "How will you know it worked? What will you watch for?"
+- "If it does not go as planned, what is the kind next move rather than the harsh one?"
+
+Frame slips as information, not failure.
+
+### 5. Align — integrate it into who you are
+Connect the action to identity and next steps. Ask:
+- "What does doing this say about the person you are becoming?"
+- "How will you carry this into your week and the rest of your life?"
+
+Close the loop and set the next check-in.
+
+## Close every session with a recap
+Give them a short, keepable summary:
+- **Reflect:** the pattern they named.
+- **Envision:** the aligned outcome and the value behind it.
+- **Execute:** the one small action (with when and where).
+- **Learn:** what they will watch for.
+- **Align:** the identity or next step it connects to.
+
+## Guardrails
+- This is guided self-coaching and reflection — **not** medical care, therapy, or a substitute for professional mental-health treatment.
+- Stay within a supportive, educational scope. Do not diagnose or give clinical advice.
+- If the person expresses crisis, thoughts of self-harm, or being in danger, gently pause the method and direct them to professional help — in the U.S., call or text **988** (Suicide & Crisis Lifeline) or contact local emergency services.
+- Keep the stance compassionate and trauma-informed: choice, small steps, and no shame.

--- a/.claude/skills/reelverse-offer-builder/SKILL.md
+++ b/.claude/skills/reelverse-offer-builder/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: reelverse-offer-builder
+description: Design and price offerings for the Shape The Wave Longevity / ReelVerse business model — memberships, bundles, packages, and services — using a consistent offer-ladder taxonomy. Use when the user wants to create a new service, package, bundle, or membership; restructure their catalog; price a new offer; or build out a productized service menu in this style.
+---
+
+# ReelVerse Offer Builder
+
+Design offerings for the **Shape The Wave Longevity™ / ReelVerse™** business using one consistent **offer ladder**. Everything ladders under: Shape The Wave Longevity™ → REEL Align Method™ → ReelVerse AI™ → ReelVerse OS™.
+
+**Core message:** Optimize health. Align habits. Live longer, better.
+
+## The offer ladder (four layers)
+Build from the bottom up — atoms first, then compose upward.
+
+1. **Services** — atomic, à-la-carte offerings (the units of value). Organize them by the five REEL Align movements — **Reflect, Envision, Execute, Learn, Align** — plus a **Practitioner & Organizational** track.
+2. **Packages** — a curated set of services aimed at **one specific outcome**.
+3. **Bundles** — larger, cross-pillar combinations, often paired with a membership term. The highest-value transformations.
+4. **Memberships** — recurring tiers giving ongoing access to ReelVerse OS and the method (e.g., Explorer (free) → Core → Plus → Pro → Practitioner).
+
+## How to design each
+- **Service:** name · which REEL Align step or pillar it serves · one-line description · format (session, course, tool, protocol) · à-la-carte price. Give each an ID (S1, S2, …).
+- **Package:** name · the services it includes (by ID) · the single outcome it delivers · price. Give each an ID (P1, P2, …).
+- **Bundle:** name · the packages + any membership term inside · target audience · price. Give each an ID (B1, B2, …).
+- **Membership:** tier name · recurring price · who it's for · what's included. Each tier up must be an obvious upgrade.
+
+## Pricing logic
+- Services are à-la-carte. **Packages** are priced **below the sum** of their services (a curation + outcome premium). **Bundles** carry a **larger discount** to reward commitment. **Memberships** are recurring.
+- Maintain a clear value ladder: every step or tier up should read as an obvious upgrade.
+- Anchor to a premium longevity/wellbeing market, and always mark prices as **suggested — the user sets final pricing to their market**.
+
+## Brand alignment
+- Use the ecosystem product names where they fit: **ReelVerse Coach** (AI guidance), **Mirror** (reflection/journaling), **Compass** (goals/values), **Momentum** (habits/progress), **Academy** (courses/certification), and the **Certified REEL Method Practitioner** credential.
+- Keep offerings consistent with the five REEL Align movements as the organizing spine.
+
+## Workflow (when helping build offers)
+1. Clarify the goal: a single new offer, a whole tier, or a catalog restructure?
+2. Start from **services** (the atoms), then compose up into **packages → bundles → memberships**.
+3. For each item, produce: ID · name · what's included · outcome/who-it's-for · suggested price.
+4. Check coherence: no orphan services, one clear outcome per package, and a clear upgrade path across memberships.
+5. Output as clean tables grouped by layer, with an at-a-glance count summary.
+
+## Guardrails
+- Prices are suggestions; the user sets final pricing.
+- **Clinical services** (e.g., narrative re-authoring / other licensed LCSW work) must be delivered within scope of practice and applicable regulations — flag these explicitly.
+- Keep claims honest: frame the offering as **wellbeing and behavior-change**, not medical treatment or a "health care system."


### PR DESCRIPTION
Adds four Claude Agent Skills under `.claude/skills/`, packaging the Shape The Wave Longevity / ReelVerse methods as reusable, auto-triggering capabilities.

| Skill | What it does |
|---|---|
| `reel-align-method` | Five-step **Reflect → Envision → Execute → Learn → Align** behavior-change coaching. |
| `reelverse-offer-builder` | Designs & prices offerings across the offer ladder — services, packages, bundles, memberships. |
| `movement-as-medicine` | Trauma-informed movement-habit coaching (four doorways, minimum-viable week, obstacle plans). |
| `narrative-reauthoring` | Clinical REEL Method — **Rewind → Empower → Edit → Live** reflective story re-authoring (not-therapy guardrails). |

Each has YAML frontmatter (`name`, `description`) so it's discoverable and auto-triggers on relevant requests, and each carries appropriate scope/safety guardrails. Opened as a **draft** for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dvj2vqogwRi3Qy1ykU16Z